### PR TITLE
Fix: Correct 'Oblvion' typos that caused two issues in new Nehrim instances

### DIFF
--- a/src/games/nehrim/gamenehrim.cpp
+++ b/src/games/nehrim/gamenehrim.cpp
@@ -66,7 +66,7 @@ QList<ExecutableForcedLoadSetting> GameNehrim::executableForcedLoads() const
 {
   // TODO Search game directory for OBSE DLLs
   return QList<ExecutableForcedLoadSetting>()
-         << ExecutableForcedLoadSetting("Oblvion.exe", "obse_1_2_416.dll")
+         << ExecutableForcedLoadSetting("Oblivion.exe", "obse_1_2_416.dll")
                 .withForced()
                 .withEnabled()
          << ExecutableForcedLoadSetting("TESConstructionSet.exe", "obse_editor_1_2.dll")
@@ -107,7 +107,7 @@ QList<PluginSetting> GameNehrim::settings() const
 void GameNehrim::initializeProfile(const QDir& path, ProfileSettings settings) const
 {
   if (settings.testFlag(IPluginGame::MODS)) {
-    copyToProfile(localAppFolder() + "/Oblvion", path, "plugins.txt");
+    copyToProfile(localAppFolder() + "/Oblivion", path, "plugins.txt");
   }
 
   if (settings.testFlag(IPluginGame::CONFIGURATION)) {


### PR DESCRIPTION
This contribution fixes two typos in strings used to create:
* The path to `plugins.txt` in the profile initialization
* The forced load setting for the main executable.