### PR TITLE
[game_fallout4vr] Allow ESL Support if Daytripper 4 is installed.

### DIFF
--- a/src/games/fallout4vr/fallout4vrgameplugins.cpp
+++ b/src/games/fallout4vr/fallout4vrgameplugins.cpp
@@ -8,7 +8,7 @@ Fallout4VRGamePlugins::Fallout4VRGamePlugins(MOBase::IOrganizer* organizer)
 
 bool Fallout4VRGamePlugins::lightPluginsAreSupported()
 {
-  auto files = m_Organizer->findFiles("f4se\\plugins", {"falloutvresl.dll"});
+  auto files = m_Organizer->findFiles("f4se\\plugins", {"falloutvresl.dll", "Daytripper4.dll"});
   if (files.isEmpty())
     return false;
   return true;

--- a/src/games/fallout4vr/fallout4vrgameplugins.cpp
+++ b/src/games/fallout4vr/fallout4vrgameplugins.cpp
@@ -8,7 +8,8 @@ Fallout4VRGamePlugins::Fallout4VRGamePlugins(MOBase::IOrganizer* organizer)
 
 bool Fallout4VRGamePlugins::lightPluginsAreSupported()
 {
-  auto files = m_Organizer->findFiles("f4se\\plugins", {"falloutvresl.dll", "Daytripper4.dll"});
+  auto files =
+      m_Organizer->findFiles("f4se\\plugins", {"falloutvresl.dll", "Daytripper4.dll"});
   if (files.isEmpty())
     return false;
   return true;


### PR DESCRIPTION
[Daytripper 4](https://www.nexusmods.com/fallout4/mods/91141) is able to add ESL support to Fallout 4 VR. This change adds it to the list of F4SE plugins that enable ESL support in Mod Organizer 2.