### PR TITLE
feat(starfield): add Terran Armada DLC plugins

### DIFF
--- a/src/games/starfield/gamestarfield.cpp
+++ b/src/games/starfield/gamestarfield.cpp
@@ -228,8 +228,8 @@ QStringList GameStarfield::primaryPlugins() const
                          "SFBGS00D.esm",
                          "SFBGS047.esm",
                          "SFBGS050.esm",
-                         "BlueprintShips-SFBGS050.esm",
-                         "BlueprintShips-Starfield.esm"};
+                         "BlueprintShips-Starfield.esm",
+                         "BlueprintShips-SFBGS050.esm"};
 
   for (auto plugin : CCCPlugins()) {
     if (!plugins.contains(plugin, Qt::CaseInsensitive)) {

--- a/src/games/starfield/gamestarfield.cpp
+++ b/src/games/starfield/gamestarfield.cpp
@@ -216,11 +216,20 @@ QStringList GameStarfield::testFilePlugins() const
 
 QStringList GameStarfield::primaryPlugins() const
 {
-  QStringList plugins = {"Starfield.esm",      "Constellation.esm",
-                         "ShatteredSpace.esm", "OldMars.esm",
-                         "SFBGS003.esm",       "SFBGS004.esm",
-                         "SFBGS006.esm",       "SFBGS007.esm",
-                         "SFBGS008.esm",       "BlueprintShips-Starfield.esm"};
+  QStringList plugins = {"Starfield.esm",
+                         "Constellation.esm",
+                         "ShatteredSpace.esm",
+                         "OldMars.esm",
+                         "SFBGS003.esm",
+                         "SFBGS004.esm",
+                         "SFBGS006.esm",
+                         "SFBGS007.esm",
+                         "SFBGS008.esm",
+                         "SFBGS00D.esm",
+                         "SFBGS047.esm",
+                         "SFBGS050.esm",
+                         "BlueprintShips-SFBGS050.esm",
+                         "BlueprintShips-Starfield.esm"};
 
   for (auto plugin : CCCPlugins()) {
     if (!plugins.contains(plugin, Qt::CaseInsensitive)) {


### PR DESCRIPTION
Include the new official Starfield DLC ESM entries in the primary plugin list. 
This keeps the built-in plugin set aligned with Terran Armada content.