### PR TITLE
Fix loot detection

### DIFF
--- a/src/gamebryo/gamegamebryo.cpp
+++ b/src/gamebryo/gamegamebryo.cpp
@@ -251,8 +251,22 @@ QString GameGamebryo::myGamesPath() const
 
 /*static*/ QString GameGamebryo::getLootPath()
 {
-  return findInRegistry(HKEY_LOCAL_MACHINE, L"Software\\LOOT", L"Installed Path") +
-         "/Loot.exe";
+  auto result = findInRegistry(
+      HKEY_CURRENT_USER,
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{BF634210-A0D4-443F-"
+      "A657-0DCE38040374}_is1",
+      L"InstallLocation");
+
+  if (result.isEmpty())
+    result = findInRegistry(
+        HKEY_LOCAL_MACHINE,
+        L"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{BF634210-A0D4-443F-"
+        "A657-0DCE38040374}_is1",
+        L"InstallLocation");
+
+  if (result.isEmpty())
+    result = findInRegistry(HKEY_LOCAL_MACHINE, L"Software\\LOOT", L"Installed Path");
+  return result + "/Loot.exe";
 }
 
 QString GameGamebryo::localAppFolder()


### PR DESCRIPTION
LOOT changed the registry path used to locate the install; this should cover all possibilities.

(See similar code in the Oblivion Reloaded basic game plugin.)