### PR TITLE
Fix save parsing for v122 saves

### DIFF
--- a/src/games/starfield/starfieldsavegame.cpp
+++ b/src/games/starfield/starfieldsavegame.cpp
@@ -109,7 +109,6 @@ std::unique_ptr<GamebryoSaveGame::DataFields> StarfieldSaveGame::fetchDataFields
     extraInfo = 1;
   if (saveVersion >= 140)
     extraInfo = 2;
-  QStringList gamePlugins = m_Game->primaryPlugins() + m_Game->enabledPlugins();
 
   QString ignore;
   std::unique_ptr<DataFields> fields = std::make_unique<DataFields>();
@@ -119,10 +118,10 @@ std::unique_ptr<GamebryoSaveGame::DataFields> StarfieldSaveGame::fetchDataFields
   file.read(ignore);  // game version again?
   file.readInt();     // plugin info size
 
-  fields->Plugins      = file.readPlugins(0, extraInfo, gamePlugins);
-  fields->LightPlugins = file.readLightPlugins(0, extraInfo, gamePlugins);
+  fields->Plugins      = file.readPlugins(0, extraInfo, v122CorePlugins);
+  fields->LightPlugins = file.readLightPlugins(0, extraInfo, v122CorePlugins);
   if (saveVersion >= 122)
-    fields->MediumPlugins = file.readMediumPlugins(0, extraInfo, gamePlugins);
+    fields->MediumPlugins = file.readMediumPlugins(0, extraInfo, v122CorePlugins);
   file.closeCompressedData();
   file.close();
 

--- a/src/games/starfield/starfieldsavegame.h
+++ b/src/games/starfield/starfieldsavegame.h
@@ -11,6 +11,11 @@ class GameStarfield;
 class StarfieldSaveGame : public GamebryoSaveGame
 {
 public:
+  const QStringList v122CorePlugins = {"Starfield.esm", "Constellation.esm",
+                                       "OldMars.esm",   "BlueprintShips-Starfield.esm",
+                                       "SFBGS003.esm",  "SFBGS006.esm",
+                                       "SFBGS007.esm",  "SFBGS008.esm"};
+
   StarfieldSaveGame(QString const& fileName, GameStarfield const* game);
 
 protected:


### PR DESCRIPTION
- Specific hardcoded core plugins had extra metadata
- Moving the blueprints out of primary plugins broke this
- The list is static and pulling the current primaries no longer makes sense