### PR TITLE
perf: Single allocation for pluginlist parsing

### DIFF
--- a/src/creation/creationgameplugins.cpp
+++ b/src/creation/creationgameplugins.cpp
@@ -134,7 +134,7 @@ QStringList CreationGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
 
   QStringList pluginsFound;
   const QByteArray contents = file.readAll();
-  qsizetype lineStart      = 0;
+  qsizetype lineStart       = 0;
   while (lineStart < contents.size()) {
     qsizetype lineEnd = contents.indexOf('\n', lineStart);
     if (lineEnd < 0) {

--- a/src/creation/creationgameplugins.cpp
+++ b/src/creation/creationgameplugins.cpp
@@ -133,12 +133,12 @@ QStringList CreationGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
   }
 
   QStringList pluginsFound;
+  QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
   while (!file.atEnd()) {
-    QByteArray line = file.readLine();
+    const qint64 bytesRead = file.readLine(line.data(), line.size());
     QString pluginName;
-    if ((line.size() > 0) && (line.at(0) != '#')) {
-      pluginName = QStringEncoder(QStringConverter::Encoding::System)
-                       .encode(line.trimmed().constData());
+    if ((bytesRead > 0) && (line.at(0) != '#')) {
+      pluginName = QString::fromLocal8Bit(line.constData(), bytesRead).trimmed();
     }
     if (!primaryPlugins.contains(pluginName, Qt::CaseInsensitive)) {
       if (pluginName.startsWith('*')) {

--- a/src/creation/creationgameplugins.cpp
+++ b/src/creation/creationgameplugins.cpp
@@ -134,17 +134,10 @@ QStringList CreationGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
 
   QStringList pluginsFound;
   const QByteArray contents = file.readAll();
-  qsizetype lineStart       = 0;
-  while (lineStart < contents.size()) {
-    qsizetype lineEnd = contents.indexOf('\n', lineStart);
-    if (lineEnd < 0) {
-      lineEnd = contents.size();
-    }
-    const qsizetype lineSize = lineEnd - lineStart;
+  for (const QByteArray& line : contents.split('\n')) {
     QString pluginName;
-    if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-      pluginName =
-          QString::fromLocal8Bit(contents.constData() + lineStart, lineSize).trimmed();
+    if ((line.size() > 0) && (line.at(0) != '#')) {
+      pluginName = QString::fromLocal8Bit(line).trimmed();
     }
     if (!primaryPlugins.contains(pluginName, Qt::CaseInsensitive)) {
       if (pluginName.startsWith('*')) {
@@ -169,7 +162,6 @@ QStringList CreationGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
       pluginName.remove(0, 1);
       pluginsFound.append(pluginName);
     }
-    lineStart = lineEnd + 1;
   }
 
   file.close();

--- a/src/creation/creationgameplugins.cpp
+++ b/src/creation/creationgameplugins.cpp
@@ -133,12 +133,18 @@ QStringList CreationGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
   }
 
   QStringList pluginsFound;
-  QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
-  while (!file.atEnd()) {
-    const qint64 bytesRead = file.readLine(line.data(), line.size());
+  const QByteArray contents = file.readAll();
+  qsizetype lineStart      = 0;
+  while (lineStart < contents.size()) {
+    qsizetype lineEnd = contents.indexOf('\n', lineStart);
+    if (lineEnd < 0) {
+      lineEnd = contents.size();
+    }
+    const qsizetype lineSize = lineEnd - lineStart;
     QString pluginName;
-    if ((bytesRead > 0) && (line.at(0) != '#')) {
-      pluginName = QString::fromLocal8Bit(line.constData(), bytesRead).trimmed();
+    if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
+      pluginName =
+          QString::fromLocal8Bit(contents.constData() + lineStart, lineSize).trimmed();
     }
     if (!primaryPlugins.contains(pluginName, Qt::CaseInsensitive)) {
       if (pluginName.startsWith('*')) {
@@ -163,6 +169,7 @@ QStringList CreationGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
       pluginName.remove(0, 1);
       pluginsFound.append(pluginName);
     }
+    lineStart = lineEnd + 1;
   }
 
   file.close();

--- a/src/gamebryo/gamebryogameplugins.cpp
+++ b/src/gamebryo/gamebryogameplugins.cpp
@@ -218,12 +218,12 @@ QStringList GamebryoGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
 
   QStringList activePlugins;
   if (pluginsTxtExists) {
+    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
     while (!file.atEnd()) {
-      QByteArray line = file.readLine();
+      const qint64 bytesRead = file.readLine(line.data(), line.size());
       QString pluginName;
-      if ((line.size() > 0) && (line.at(0) != '#')) {
-        QStringEncoder encoder(QStringConverter::Encoding::System);
-        pluginName = encoder.encode(line.trimmed().constData());
+      if ((bytesRead > 0) && (line.at(0) != '#')) {
+        pluginName = QString::fromLocal8Bit(line.constData(), bytesRead).trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);

--- a/src/gamebryo/gamebryogameplugins.cpp
+++ b/src/gamebryo/gamebryogameplugins.cpp
@@ -218,17 +218,24 @@ QStringList GamebryoGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
 
   QStringList activePlugins;
   if (pluginsTxtExists) {
-    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
-    while (!file.atEnd()) {
-      const qint64 bytesRead = file.readLine(line.data(), line.size());
+    const QByteArray contents = file.readAll();
+    qsizetype lineStart      = 0;
+    while (lineStart < contents.size()) {
+      qsizetype lineEnd = contents.indexOf('\n', lineStart);
+      if (lineEnd < 0) {
+        lineEnd = contents.size();
+      }
+      const qsizetype lineSize = lineEnd - lineStart;
       QString pluginName;
-      if ((bytesRead > 0) && (line.at(0) != '#')) {
-        pluginName = QString::fromLocal8Bit(line.constData(), bytesRead).trimmed();
+      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
+        pluginName =
+            QString::fromLocal8Bit(contents.constData() + lineStart, lineSize).trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);
         activePlugins.push_back(pluginName);
       }
+      lineStart = lineEnd + 1;
     }
 
     for (const auto& pluginName : plugins) {

--- a/src/gamebryo/gamebryogameplugins.cpp
+++ b/src/gamebryo/gamebryogameplugins.cpp
@@ -219,7 +219,7 @@ QStringList GamebryoGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
   QStringList activePlugins;
   if (pluginsTxtExists) {
     const QByteArray contents = file.readAll();
-    qsizetype lineStart      = 0;
+    qsizetype lineStart       = 0;
     while (lineStart < contents.size()) {
       qsizetype lineEnd = contents.indexOf('\n', lineStart);
       if (lineEnd < 0) {
@@ -228,8 +228,8 @@ QStringList GamebryoGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
       const qsizetype lineSize = lineEnd - lineStart;
       QString pluginName;
       if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        pluginName =
-            QString::fromLocal8Bit(contents.constData() + lineStart, lineSize).trimmed();
+        pluginName = QString::fromLocal8Bit(contents.constData() + lineStart, lineSize)
+                         .trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);

--- a/src/gamebryo/gamebryogameplugins.cpp
+++ b/src/gamebryo/gamebryogameplugins.cpp
@@ -219,23 +219,15 @@ QStringList GamebryoGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
   QStringList activePlugins;
   if (pluginsTxtExists) {
     const QByteArray contents = file.readAll();
-    qsizetype lineStart       = 0;
-    while (lineStart < contents.size()) {
-      qsizetype lineEnd = contents.indexOf('\n', lineStart);
-      if (lineEnd < 0) {
-        lineEnd = contents.size();
-      }
-      const qsizetype lineSize = lineEnd - lineStart;
+    for (const QByteArray& line : contents.split('\n')) {
       QString pluginName;
-      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        pluginName = QString::fromLocal8Bit(contents.constData() + lineStart, lineSize)
-                         .trimmed();
+      if ((line.size() > 0) && (line.at(0) != '#')) {
+        pluginName = QString::fromLocal8Bit(line).trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);
         activePlugins.push_back(pluginName);
       }
-      lineStart = lineEnd + 1;
     }
 
     for (const auto& pluginName : plugins) {

--- a/src/games/enderal/enderalgameplugins.cpp
+++ b/src/games/enderal/enderalgameplugins.cpp
@@ -92,12 +92,18 @@ QStringList EnderalGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
   }
 
   if (pluginsTxtExists) {
-    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
-    while (!file.atEnd()) {
-      const qint64 bytesRead = file.readLine(line.data(), line.size());
+    const QByteArray contents = file.readAll();
+    qsizetype lineStart      = 0;
+    while (lineStart < contents.size()) {
+      qsizetype lineEnd = contents.indexOf('\n', lineStart);
+      if (lineEnd < 0) {
+        lineEnd = contents.size();
+      }
+      const qsizetype lineSize = lineEnd - lineStart;
       QString pluginName;
-      if ((bytesRead > 0) && (line.at(0) != '#')) {
-        pluginName = QString::fromLocal8Bit(line.constData(), bytesRead).trimmed();
+      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
+        pluginName =
+            QString::fromLocal8Bit(contents.constData() + lineStart, lineSize).trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);
@@ -105,6 +111,7 @@ QStringList EnderalGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
         // we already have the old loadorder and we ignore the positions in plugins.txt
         // (needs fix) loadOrder.append(pluginName);
       }
+      lineStart = lineEnd + 1;
     }
 
     file.close();

--- a/src/games/enderal/enderalgameplugins.cpp
+++ b/src/games/enderal/enderalgameplugins.cpp
@@ -93,7 +93,7 @@ QStringList EnderalGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
 
   if (pluginsTxtExists) {
     const QByteArray contents = file.readAll();
-    qsizetype lineStart      = 0;
+    qsizetype lineStart       = 0;
     while (lineStart < contents.size()) {
       qsizetype lineEnd = contents.indexOf('\n', lineStart);
       if (lineEnd < 0) {
@@ -102,8 +102,8 @@ QStringList EnderalGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
       const qsizetype lineSize = lineEnd - lineStart;
       QString pluginName;
       if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        pluginName =
-            QString::fromLocal8Bit(contents.constData() + lineStart, lineSize).trimmed();
+        pluginName = QString::fromLocal8Bit(contents.constData() + lineStart, lineSize)
+                         .trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);

--- a/src/games/enderal/enderalgameplugins.cpp
+++ b/src/games/enderal/enderalgameplugins.cpp
@@ -93,17 +93,10 @@ QStringList EnderalGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
 
   if (pluginsTxtExists) {
     const QByteArray contents = file.readAll();
-    qsizetype lineStart       = 0;
-    while (lineStart < contents.size()) {
-      qsizetype lineEnd = contents.indexOf('\n', lineStart);
-      if (lineEnd < 0) {
-        lineEnd = contents.size();
-      }
-      const qsizetype lineSize = lineEnd - lineStart;
+    for (const QByteArray& line : contents.split('\n')) {
       QString pluginName;
-      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        pluginName = QString::fromLocal8Bit(contents.constData() + lineStart, lineSize)
-                         .trimmed();
+      if ((line.size() > 0) && (line.at(0) != '#')) {
+        pluginName = QString::fromLocal8Bit(line).trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);
@@ -111,7 +104,6 @@ QStringList EnderalGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
         // we already have the old loadorder and we ignore the positions in plugins.txt
         // (needs fix) loadOrder.append(pluginName);
       }
-      lineStart = lineEnd + 1;
     }
 
     file.close();

--- a/src/games/enderal/enderalgameplugins.cpp
+++ b/src/games/enderal/enderalgameplugins.cpp
@@ -92,12 +92,12 @@ QStringList EnderalGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
   }
 
   if (pluginsTxtExists) {
+    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
     while (!file.atEnd()) {
-      QByteArray line = file.readLine();
+      const qint64 bytesRead = file.readLine(line.data(), line.size());
       QString pluginName;
-      if ((line.size() > 0) && (line.at(0) != '#')) {
-        pluginName = QStringEncoder(QStringConverter::Encoding::System)
-                         .encode(line.trimmed().constData());
+      if ((bytesRead > 0) && (line.at(0) != '#')) {
+        pluginName = QString::fromLocal8Bit(line.constData(), bytesRead).trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);

--- a/src/games/fallout4/gamefallout4.cpp
+++ b/src/games/fallout4/gamefallout4.cpp
@@ -255,12 +255,18 @@ QStringList GameFallout4::CCPlugins() const
     if (file.size() == 0) {
       return plugins;
     }
-    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
-    while (!file.atEnd()) {
-      const qint64 bytesRead = file.readLine(line.data(), line.size());
+    const QByteArray contents = file.readAll();
+    qsizetype lineStart      = 0;
+    while (lineStart < contents.size()) {
+      qsizetype lineEnd = contents.indexOf('\n', lineStart);
+      if (lineEnd < 0) {
+        lineEnd = contents.size();
+      }
+      const qsizetype lineSize = lineEnd - lineStart;
       QString modName;
-      if ((bytesRead > 0) && (line.at(0) != '#')) {
-        modName = QString::fromUtf8(line.constData(), bytesRead).trimmed().toLower();
+      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
+        modName =
+            QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed().toLower();
       }
 
       if (modName.size() > 0) {
@@ -268,6 +274,7 @@ QStringList GameFallout4::CCPlugins() const
           plugins.append(modName);
         }
       }
+      lineStart = lineEnd + 1;
     }
   }
   return plugins;

--- a/src/games/fallout4/gamefallout4.cpp
+++ b/src/games/fallout4/gamefallout4.cpp
@@ -255,11 +255,12 @@ QStringList GameFallout4::CCPlugins() const
     if (file.size() == 0) {
       return plugins;
     }
+    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
     while (!file.atEnd()) {
-      QByteArray line = file.readLine().trimmed();
+      const qint64 bytesRead = file.readLine(line.data(), line.size());
       QString modName;
-      if ((line.size() > 0) && (line.at(0) != '#')) {
-        modName = QString::fromUtf8(line.constData()).toLower();
+      if ((bytesRead > 0) && (line.at(0) != '#')) {
+        modName = QString::fromUtf8(line.constData(), bytesRead).trimmed().toLower();
       }
 
       if (modName.size() > 0) {

--- a/src/games/fallout4/gamefallout4.cpp
+++ b/src/games/fallout4/gamefallout4.cpp
@@ -256,18 +256,10 @@ QStringList GameFallout4::CCPlugins() const
       return plugins;
     }
     const QByteArray contents = file.readAll();
-    qsizetype lineStart       = 0;
-    while (lineStart < contents.size()) {
-      qsizetype lineEnd = contents.indexOf('\n', lineStart);
-      if (lineEnd < 0) {
-        lineEnd = contents.size();
-      }
-      const qsizetype lineSize = lineEnd - lineStart;
+    for (const QByteArray& line : contents.split('\n')) {
       QString modName;
-      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        modName = QString::fromUtf8(contents.constData() + lineStart, lineSize)
-                      .trimmed()
-                      .toLower();
+      if ((line.size() > 0) && (line.at(0) != '#')) {
+        modName = QString::fromUtf8(line).trimmed().toLower();
       }
 
       if (modName.size() > 0) {
@@ -275,7 +267,6 @@ QStringList GameFallout4::CCPlugins() const
           plugins.append(modName);
         }
       }
-      lineStart = lineEnd + 1;
     }
   }
   return plugins;

--- a/src/games/fallout4/gamefallout4.cpp
+++ b/src/games/fallout4/gamefallout4.cpp
@@ -256,7 +256,7 @@ QStringList GameFallout4::CCPlugins() const
       return plugins;
     }
     const QByteArray contents = file.readAll();
-    qsizetype lineStart      = 0;
+    qsizetype lineStart       = 0;
     while (lineStart < contents.size()) {
       qsizetype lineEnd = contents.indexOf('\n', lineStart);
       if (lineEnd < 0) {
@@ -265,8 +265,9 @@ QStringList GameFallout4::CCPlugins() const
       const qsizetype lineSize = lineEnd - lineStart;
       QString modName;
       if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        modName =
-            QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed().toLower();
+        modName = QString::fromUtf8(contents.constData() + lineStart, lineSize)
+                      .trimmed()
+                      .toLower();
       }
 
       if (modName.size() > 0) {

--- a/src/games/fallout4london/gamefo4london.cpp
+++ b/src/games/fallout4london/gamefo4london.cpp
@@ -283,11 +283,12 @@ QStringList GameFallout4London::CCPlugins() const
     if (file.size() == 0) {
       return plugins;
     }
+    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
     while (!file.atEnd()) {
-      QByteArray line = file.readLine().trimmed();
+      const qint64 bytesRead = file.readLine(line.data(), line.size());
       QString modName;
-      if ((line.size() > 0) && (line.at(0) != '#')) {
-        modName = QString::fromUtf8(line.constData()).toLower();
+      if ((bytesRead > 0) && (line.at(0) != '#')) {
+        modName = QString::fromUtf8(line.constData(), bytesRead).trimmed().toLower();
       }
 
       if (modName.size() > 0) {

--- a/src/games/fallout4london/gamefo4london.cpp
+++ b/src/games/fallout4london/gamefo4london.cpp
@@ -283,12 +283,18 @@ QStringList GameFallout4London::CCPlugins() const
     if (file.size() == 0) {
       return plugins;
     }
-    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
-    while (!file.atEnd()) {
-      const qint64 bytesRead = file.readLine(line.data(), line.size());
+    const QByteArray contents = file.readAll();
+    qsizetype lineStart      = 0;
+    while (lineStart < contents.size()) {
+      qsizetype lineEnd = contents.indexOf('\n', lineStart);
+      if (lineEnd < 0) {
+        lineEnd = contents.size();
+      }
+      const qsizetype lineSize = lineEnd - lineStart;
       QString modName;
-      if ((bytesRead > 0) && (line.at(0) != '#')) {
-        modName = QString::fromUtf8(line.constData(), bytesRead).trimmed().toLower();
+      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
+        modName =
+            QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed().toLower();
       }
 
       if (modName.size() > 0) {
@@ -296,6 +302,7 @@ QStringList GameFallout4London::CCPlugins() const
           plugins.append(modName);
         }
       }
+      lineStart = lineEnd + 1;
     }
   }
   return plugins;

--- a/src/games/fallout4london/gamefo4london.cpp
+++ b/src/games/fallout4london/gamefo4london.cpp
@@ -284,7 +284,7 @@ QStringList GameFallout4London::CCPlugins() const
       return plugins;
     }
     const QByteArray contents = file.readAll();
-    qsizetype lineStart      = 0;
+    qsizetype lineStart       = 0;
     while (lineStart < contents.size()) {
       qsizetype lineEnd = contents.indexOf('\n', lineStart);
       if (lineEnd < 0) {
@@ -293,8 +293,9 @@ QStringList GameFallout4London::CCPlugins() const
       const qsizetype lineSize = lineEnd - lineStart;
       QString modName;
       if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        modName =
-            QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed().toLower();
+        modName = QString::fromUtf8(contents.constData() + lineStart, lineSize)
+                      .trimmed()
+                      .toLower();
       }
 
       if (modName.size() > 0) {

--- a/src/games/fallout4london/gamefo4london.cpp
+++ b/src/games/fallout4london/gamefo4london.cpp
@@ -284,18 +284,10 @@ QStringList GameFallout4London::CCPlugins() const
       return plugins;
     }
     const QByteArray contents = file.readAll();
-    qsizetype lineStart       = 0;
-    while (lineStart < contents.size()) {
-      qsizetype lineEnd = contents.indexOf('\n', lineStart);
-      if (lineEnd < 0) {
-        lineEnd = contents.size();
-      }
-      const qsizetype lineSize = lineEnd - lineStart;
+    for (const QByteArray& line : contents.split('\n')) {
       QString modName;
-      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        modName = QString::fromUtf8(contents.constData() + lineStart, lineSize)
-                      .trimmed()
-                      .toLower();
+      if ((line.size() > 0) && (line.at(0) != '#')) {
+        modName = QString::fromUtf8(line).trimmed().toLower();
       }
 
       if (modName.size() > 0) {
@@ -303,7 +295,6 @@ QStringList GameFallout4London::CCPlugins() const
           plugins.append(modName);
         }
       }
-      lineStart = lineEnd + 1;
     }
   }
   return plugins;

--- a/src/games/fallout4vr/gamefallout4vr.cpp
+++ b/src/games/fallout4vr/gamefallout4vr.cpp
@@ -201,11 +201,12 @@ QStringList GameFallout4VR::CCPlugins() const
     if (file.size() == 0) {
       return plugins;
     }
+    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
     while (!file.atEnd()) {
-      QByteArray line = file.readLine().trimmed();
+      const qint64 bytesRead = file.readLine(line.data(), line.size());
       QString modName;
-      if ((line.size() > 0) && (line.at(0) != '#')) {
-        modName = QString::fromUtf8(line.constData()).toLower();
+      if ((bytesRead > 0) && (line.at(0) != '#')) {
+        modName = QString::fromUtf8(line.constData(), bytesRead).trimmed().toLower();
       }
 
       if (modName.size() > 0) {

--- a/src/games/fallout4vr/gamefallout4vr.cpp
+++ b/src/games/fallout4vr/gamefallout4vr.cpp
@@ -202,18 +202,10 @@ QStringList GameFallout4VR::CCPlugins() const
       return plugins;
     }
     const QByteArray contents = file.readAll();
-    qsizetype lineStart       = 0;
-    while (lineStart < contents.size()) {
-      qsizetype lineEnd = contents.indexOf('\n', lineStart);
-      if (lineEnd < 0) {
-        lineEnd = contents.size();
-      }
-      const qsizetype lineSize = lineEnd - lineStart;
+    for (const QByteArray& line : contents.split('\n')) {
       QString modName;
-      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        modName = QString::fromUtf8(contents.constData() + lineStart, lineSize)
-                      .trimmed()
-                      .toLower();
+      if ((line.size() > 0) && (line.at(0) != '#')) {
+        modName = QString::fromUtf8(line).trimmed().toLower();
       }
 
       if (modName.size() > 0) {
@@ -221,7 +213,6 @@ QStringList GameFallout4VR::CCPlugins() const
           plugins.append(modName);
         }
       }
-      lineStart = lineEnd + 1;
     }
   }
   return plugins;

--- a/src/games/fallout4vr/gamefallout4vr.cpp
+++ b/src/games/fallout4vr/gamefallout4vr.cpp
@@ -201,12 +201,18 @@ QStringList GameFallout4VR::CCPlugins() const
     if (file.size() == 0) {
       return plugins;
     }
-    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
-    while (!file.atEnd()) {
-      const qint64 bytesRead = file.readLine(line.data(), line.size());
+    const QByteArray contents = file.readAll();
+    qsizetype lineStart      = 0;
+    while (lineStart < contents.size()) {
+      qsizetype lineEnd = contents.indexOf('\n', lineStart);
+      if (lineEnd < 0) {
+        lineEnd = contents.size();
+      }
+      const qsizetype lineSize = lineEnd - lineStart;
       QString modName;
-      if ((bytesRead > 0) && (line.at(0) != '#')) {
-        modName = QString::fromUtf8(line.constData(), bytesRead).trimmed().toLower();
+      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
+        modName =
+            QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed().toLower();
       }
 
       if (modName.size() > 0) {
@@ -214,6 +220,7 @@ QStringList GameFallout4VR::CCPlugins() const
           plugins.append(modName);
         }
       }
+      lineStart = lineEnd + 1;
     }
   }
   return plugins;

--- a/src/games/fallout4vr/gamefallout4vr.cpp
+++ b/src/games/fallout4vr/gamefallout4vr.cpp
@@ -202,7 +202,7 @@ QStringList GameFallout4VR::CCPlugins() const
       return plugins;
     }
     const QByteArray contents = file.readAll();
-    qsizetype lineStart      = 0;
+    qsizetype lineStart       = 0;
     while (lineStart < contents.size()) {
       qsizetype lineEnd = contents.indexOf('\n', lineStart);
       if (lineEnd < 0) {
@@ -211,8 +211,9 @@ QStringList GameFallout4VR::CCPlugins() const
       const qsizetype lineSize = lineEnd - lineStart;
       QString modName;
       if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        modName =
-            QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed().toLower();
+        modName = QString::fromUtf8(contents.constData() + lineStart, lineSize)
+                      .trimmed()
+                      .toLower();
       }
 
       if (modName.size() > 0) {

--- a/src/games/fallout76/gamefallout76.cpp
+++ b/src/games/fallout76/gamefallout76.cpp
@@ -189,12 +189,18 @@ QStringList GameFallout76::CCPlugins() const
     if (file.size() == 0) {
       return plugins;
     }
-    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
-    while (!file.atEnd()) {
-      const qint64 bytesRead = file.readLine(line.data(), line.size());
+    const QByteArray contents = file.readAll();
+    qsizetype lineStart      = 0;
+    while (lineStart < contents.size()) {
+      qsizetype lineEnd = contents.indexOf('\n', lineStart);
+      if (lineEnd < 0) {
+        lineEnd = contents.size();
+      }
+      const qsizetype lineSize = lineEnd - lineStart;
       QString modName;
-      if ((bytesRead > 0) && (line.at(0) != '#')) {
-        modName = QString::fromUtf8(line.constData(), bytesRead).trimmed().toLower();
+      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
+        modName =
+            QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed().toLower();
       }
 
       if (modName.size() > 0) {
@@ -202,6 +208,7 @@ QStringList GameFallout76::CCPlugins() const
           plugins.append(modName);
         }
       }
+      lineStart = lineEnd + 1;
     }
   }
   return plugins;

--- a/src/games/fallout76/gamefallout76.cpp
+++ b/src/games/fallout76/gamefallout76.cpp
@@ -189,11 +189,12 @@ QStringList GameFallout76::CCPlugins() const
     if (file.size() == 0) {
       return plugins;
     }
+    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
     while (!file.atEnd()) {
-      QByteArray line = file.readLine().trimmed();
+      const qint64 bytesRead = file.readLine(line.data(), line.size());
       QString modName;
-      if ((line.size() > 0) && (line.at(0) != '#')) {
-        modName = QString::fromUtf8(line.constData()).toLower();
+      if ((bytesRead > 0) && (line.at(0) != '#')) {
+        modName = QString::fromUtf8(line.constData(), bytesRead).trimmed().toLower();
       }
 
       if (modName.size() > 0) {

--- a/src/games/fallout76/gamefallout76.cpp
+++ b/src/games/fallout76/gamefallout76.cpp
@@ -190,18 +190,10 @@ QStringList GameFallout76::CCPlugins() const
       return plugins;
     }
     const QByteArray contents = file.readAll();
-    qsizetype lineStart       = 0;
-    while (lineStart < contents.size()) {
-      qsizetype lineEnd = contents.indexOf('\n', lineStart);
-      if (lineEnd < 0) {
-        lineEnd = contents.size();
-      }
-      const qsizetype lineSize = lineEnd - lineStart;
+    for (const QByteArray& line : contents.split('\n')) {
       QString modName;
-      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        modName = QString::fromUtf8(contents.constData() + lineStart, lineSize)
-                      .trimmed()
-                      .toLower();
+      if ((line.size() > 0) && (line.at(0) != '#')) {
+        modName = QString::fromUtf8(line).trimmed().toLower();
       }
 
       if (modName.size() > 0) {
@@ -209,7 +201,6 @@ QStringList GameFallout76::CCPlugins() const
           plugins.append(modName);
         }
       }
-      lineStart = lineEnd + 1;
     }
   }
   return plugins;

--- a/src/games/fallout76/gamefallout76.cpp
+++ b/src/games/fallout76/gamefallout76.cpp
@@ -190,7 +190,7 @@ QStringList GameFallout76::CCPlugins() const
       return plugins;
     }
     const QByteArray contents = file.readAll();
-    qsizetype lineStart      = 0;
+    qsizetype lineStart       = 0;
     while (lineStart < contents.size()) {
       qsizetype lineEnd = contents.indexOf('\n', lineStart);
       if (lineEnd < 0) {
@@ -199,8 +199,9 @@ QStringList GameFallout76::CCPlugins() const
       const qsizetype lineSize = lineEnd - lineStart;
       QString modName;
       if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        modName =
-            QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed().toLower();
+        modName = QString::fromUtf8(contents.constData() + lineStart, lineSize)
+                      .trimmed()
+                      .toLower();
       }
 
       if (modName.size() > 0) {

--- a/src/games/skyrim/skyrimgameplugins.cpp
+++ b/src/games/skyrim/skyrimgameplugins.cpp
@@ -93,7 +93,7 @@ QStringList SkyrimGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
 
   if (pluginsTxtExists) {
     const QByteArray contents = file.readAll();
-    qsizetype lineStart      = 0;
+    qsizetype lineStart       = 0;
     while (lineStart < contents.size()) {
       qsizetype lineEnd = contents.indexOf('\n', lineStart);
       if (lineEnd < 0) {
@@ -102,8 +102,8 @@ QStringList SkyrimGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
       const qsizetype lineSize = lineEnd - lineStart;
       QString pluginName;
       if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        pluginName =
-            QString::fromLocal8Bit(contents.constData() + lineStart, lineSize).trimmed();
+        pluginName = QString::fromLocal8Bit(contents.constData() + lineStart, lineSize)
+                         .trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);

--- a/src/games/skyrim/skyrimgameplugins.cpp
+++ b/src/games/skyrim/skyrimgameplugins.cpp
@@ -93,17 +93,10 @@ QStringList SkyrimGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
 
   if (pluginsTxtExists) {
     const QByteArray contents = file.readAll();
-    qsizetype lineStart       = 0;
-    while (lineStart < contents.size()) {
-      qsizetype lineEnd = contents.indexOf('\n', lineStart);
-      if (lineEnd < 0) {
-        lineEnd = contents.size();
-      }
-      const qsizetype lineSize = lineEnd - lineStart;
+    for (const QByteArray& line : contents.split('\n')) {
       QString pluginName;
-      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        pluginName = QString::fromLocal8Bit(contents.constData() + lineStart, lineSize)
-                         .trimmed();
+      if ((line.size() > 0) && (line.at(0) != '#')) {
+        pluginName = QString::fromLocal8Bit(line).trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);
@@ -111,7 +104,6 @@ QStringList SkyrimGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
         // we already have the old loadorder and we ignore the positions in plugins.txt
         // (needs fix) loadOrder.append(pluginName);
       }
-      lineStart = lineEnd + 1;
     }
 
     file.close();

--- a/src/games/skyrim/skyrimgameplugins.cpp
+++ b/src/games/skyrim/skyrimgameplugins.cpp
@@ -92,12 +92,12 @@ QStringList SkyrimGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
   }
 
   if (pluginsTxtExists) {
+    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
     while (!file.atEnd()) {
-      QByteArray line = file.readLine();
+      const qint64 bytesRead = file.readLine(line.data(), line.size());
       QString pluginName;
-      if ((line.size() > 0) && (line.at(0) != '#')) {
-        pluginName = QStringEncoder(QStringConverter::Encoding::System)
-                         .encode(line.trimmed().constData());
+      if ((bytesRead > 0) && (line.at(0) != '#')) {
+        pluginName = QString::fromLocal8Bit(line.constData(), bytesRead).trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);

--- a/src/games/skyrim/skyrimgameplugins.cpp
+++ b/src/games/skyrim/skyrimgameplugins.cpp
@@ -92,12 +92,18 @@ QStringList SkyrimGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
   }
 
   if (pluginsTxtExists) {
-    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
-    while (!file.atEnd()) {
-      const qint64 bytesRead = file.readLine(line.data(), line.size());
+    const QByteArray contents = file.readAll();
+    qsizetype lineStart      = 0;
+    while (lineStart < contents.size()) {
+      qsizetype lineEnd = contents.indexOf('\n', lineStart);
+      if (lineEnd < 0) {
+        lineEnd = contents.size();
+      }
+      const qsizetype lineSize = lineEnd - lineStart;
       QString pluginName;
-      if ((bytesRead > 0) && (line.at(0) != '#')) {
-        pluginName = QString::fromLocal8Bit(line.constData(), bytesRead).trimmed();
+      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
+        pluginName =
+            QString::fromLocal8Bit(contents.constData() + lineStart, lineSize).trimmed();
       }
       if (pluginName.size() > 0) {
         pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);
@@ -105,6 +111,7 @@ QStringList SkyrimGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
         // we already have the old loadorder and we ignore the positions in plugins.txt
         // (needs fix) loadOrder.append(pluginName);
       }
+      lineStart = lineEnd + 1;
     }
 
     file.close();

--- a/src/games/skyrimvr/gameskyrimvr.cpp
+++ b/src/games/skyrimvr/gameskyrimvr.cpp
@@ -240,7 +240,7 @@ QStringList GameSkyrimVR::CCPlugins() const
       return plugins;
     }
     const QByteArray contents = file.readAll();
-    qsizetype lineStart      = 0;
+    qsizetype lineStart       = 0;
     while (lineStart < contents.size()) {
       qsizetype lineEnd = contents.indexOf('\n', lineStart);
       if (lineEnd < 0) {
@@ -249,8 +249,9 @@ QStringList GameSkyrimVR::CCPlugins() const
       const qsizetype lineSize = lineEnd - lineStart;
       QString modName;
       if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        modName =
-            QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed().toLower();
+        modName = QString::fromUtf8(contents.constData() + lineStart, lineSize)
+                      .trimmed()
+                      .toLower();
       }
 
       if (modName.size() > 0) {

--- a/src/games/skyrimvr/gameskyrimvr.cpp
+++ b/src/games/skyrimvr/gameskyrimvr.cpp
@@ -240,18 +240,10 @@ QStringList GameSkyrimVR::CCPlugins() const
       return plugins;
     }
     const QByteArray contents = file.readAll();
-    qsizetype lineStart       = 0;
-    while (lineStart < contents.size()) {
-      qsizetype lineEnd = contents.indexOf('\n', lineStart);
-      if (lineEnd < 0) {
-        lineEnd = contents.size();
-      }
-      const qsizetype lineSize = lineEnd - lineStart;
+    for (const QByteArray& line : contents.split('\n')) {
       QString modName;
-      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-        modName = QString::fromUtf8(contents.constData() + lineStart, lineSize)
-                      .trimmed()
-                      .toLower();
+      if ((line.size() > 0) && (line.at(0) != '#')) {
+        modName = QString::fromUtf8(line).trimmed().toLower();
       }
 
       if (modName.size() > 0) {
@@ -259,7 +251,6 @@ QStringList GameSkyrimVR::CCPlugins() const
           plugins.append(modName);
         }
       }
-      lineStart = lineEnd + 1;
     }
   }
   return plugins;

--- a/src/games/skyrimvr/gameskyrimvr.cpp
+++ b/src/games/skyrimvr/gameskyrimvr.cpp
@@ -239,11 +239,12 @@ QStringList GameSkyrimVR::CCPlugins() const
     if (file.size() == 0) {
       return plugins;
     }
+    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
     while (!file.atEnd()) {
-      QByteArray line = file.readLine().trimmed();
+      const qint64 bytesRead = file.readLine(line.data(), line.size());
       QString modName;
-      if ((line.size() > 0) && (line.at(0) != '#')) {
-        modName = QString::fromUtf8(line.constData()).toLower();
+      if ((bytesRead > 0) && (line.at(0) != '#')) {
+        modName = QString::fromUtf8(line.constData(), bytesRead).trimmed().toLower();
       }
 
       if (modName.size() > 0) {

--- a/src/games/skyrimvr/gameskyrimvr.cpp
+++ b/src/games/skyrimvr/gameskyrimvr.cpp
@@ -239,12 +239,18 @@ QStringList GameSkyrimVR::CCPlugins() const
     if (file.size() == 0) {
       return plugins;
     }
-    QByteArray line(static_cast<qsizetype>(file.size() + 1), Qt::Uninitialized);
-    while (!file.atEnd()) {
-      const qint64 bytesRead = file.readLine(line.data(), line.size());
+    const QByteArray contents = file.readAll();
+    qsizetype lineStart      = 0;
+    while (lineStart < contents.size()) {
+      qsizetype lineEnd = contents.indexOf('\n', lineStart);
+      if (lineEnd < 0) {
+        lineEnd = contents.size();
+      }
+      const qsizetype lineSize = lineEnd - lineStart;
       QString modName;
-      if ((bytesRead > 0) && (line.at(0) != '#')) {
-        modName = QString::fromUtf8(line.constData(), bytesRead).trimmed().toLower();
+      if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
+        modName =
+            QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed().toLower();
       }
 
       if (modName.size() > 0) {
@@ -252,6 +258,7 @@ QStringList GameSkyrimVR::CCPlugins() const
           plugins.append(modName);
         }
       }
+      lineStart = lineEnd + 1;
     }
   }
   return plugins;

--- a/src/games/starfield/gamestarfield.cpp
+++ b/src/games/starfield/gamestarfield.cpp
@@ -291,22 +291,14 @@ QStringList GameStarfield::CCCPlugins() const
     if (file->open(QIODevice::ReadOnly)) {
       if (file->size() > 0) {
         const QByteArray contents = file->readAll();
-        qsizetype lineStart       = 0;
-        while (lineStart < contents.size()) {
-          qsizetype lineEnd = contents.indexOf('\n', lineStart);
-          if (lineEnd < 0) {
-            lineEnd = contents.size();
-          }
-          const qsizetype lineSize = lineEnd - lineStart;
+        for (const QByteArray& line : contents.split('\n')) {
           QString modName;
-          if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
-            modName =
-                QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed();
+          if ((line.size() > 0) && (line.at(0) != '#')) {
+            modName = QString::fromUtf8(line).trimmed();
           }
           if (modName.size() > 0) {
             plugins.append(modName);
           }
-          lineStart = lineEnd + 1;
         }
       }
     }

--- a/src/games/starfield/gamestarfield.cpp
+++ b/src/games/starfield/gamestarfield.cpp
@@ -290,16 +290,23 @@ QStringList GameStarfield::CCCPlugins() const
     }
     if (file->open(QIODevice::ReadOnly)) {
       if (file->size() > 0) {
-        QByteArray line(static_cast<qsizetype>(file->size() + 1), Qt::Uninitialized);
-        while (!file->atEnd()) {
-          const qint64 bytesRead = file->readLine(line.data(), line.size());
+        const QByteArray contents = file->readAll();
+        qsizetype lineStart      = 0;
+        while (lineStart < contents.size()) {
+          qsizetype lineEnd = contents.indexOf('\n', lineStart);
+          if (lineEnd < 0) {
+            lineEnd = contents.size();
+          }
+          const qsizetype lineSize = lineEnd - lineStart;
           QString modName;
-          if ((bytesRead > 0) && (line.at(0) != '#')) {
-            modName = QString::fromUtf8(line.constData(), bytesRead).trimmed();
+          if ((lineSize > 0) && (contents.at(lineStart) != '#')) {
+            modName =
+                QString::fromUtf8(contents.constData() + lineStart, lineSize).trimmed();
           }
           if (modName.size() > 0) {
             plugins.append(modName);
           }
+          lineStart = lineEnd + 1;
         }
       }
     }

--- a/src/games/starfield/gamestarfield.cpp
+++ b/src/games/starfield/gamestarfield.cpp
@@ -291,7 +291,7 @@ QStringList GameStarfield::CCCPlugins() const
     if (file->open(QIODevice::ReadOnly)) {
       if (file->size() > 0) {
         const QByteArray contents = file->readAll();
-        qsizetype lineStart      = 0;
+        qsizetype lineStart       = 0;
         while (lineStart < contents.size()) {
           qsizetype lineEnd = contents.indexOf('\n', lineStart);
           if (lineEnd < 0) {

--- a/src/games/starfield/gamestarfield.cpp
+++ b/src/games/starfield/gamestarfield.cpp
@@ -290,11 +290,12 @@ QStringList GameStarfield::CCCPlugins() const
     }
     if (file->open(QIODevice::ReadOnly)) {
       if (file->size() > 0) {
+        QByteArray line(static_cast<qsizetype>(file->size() + 1), Qt::Uninitialized);
         while (!file->atEnd()) {
-          QByteArray line = file->readLine().trimmed();
+          const qint64 bytesRead = file->readLine(line.data(), line.size());
           QString modName;
-          if ((line.size() > 0) && (line.at(0) != '#')) {
-            modName = QString::fromUtf8(line.constData());
+          if ((bytesRead > 0) && (line.at(0) != '#')) {
+            modName = QString::fromUtf8(line.constData(), bytesRead).trimmed();
           }
           if (modName.size() > 0) {
             plugins.append(modName);


### PR DESCRIPTION
Title. Constantly allocating and deallocating memory (QByteArray) gets expensive when you got a bunch of plugins.
From personal testing: readPluginList call went from average of 605ms to 9.6ms

Additionally, this type of fix (single-allocation for QByteArray readLine's) could be applied to MO2 too, but I don't have a build environment set up for that and I don't plan to push untested changes :P